### PR TITLE
[SECURITY] Fix SEC-2025-011: implement certificate pinning

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E203,W503

--- a/tests/test_ssl_pinning.py
+++ b/tests/test_ssl_pinning.py
@@ -1,0 +1,9 @@
+from secure_ohlcv_downloader import SecureOHLCVDownloader, FingerprintAdapter
+
+
+def test_create_pinned_session(tmp_path):
+    downloader = SecureOHLCVDownloader(str(tmp_path))
+    session = downloader._create_pinned_session("https://example.com", "AA" * 32)
+    adapter = session.get_adapter("https://example.com")
+    assert isinstance(adapter, FingerprintAdapter)
+    assert adapter.fingerprint == "aa" * 32


### PR DESCRIPTION
## Security Audit Remediation

**Finding ID**: SEC-2025-011
**Severity**: HIGH
**Category**: Security

### Problem Summary
The downloader relied on default SSL verification when contacting Alpha Vantage. This lacked certificate validation or pinning, leaving the application vulnerable to MITM attacks.

### Solution Implemented
- Added `FingerprintAdapter` with SHA256 fingerprint checking.
- Created `_create_pinned_session` helper to enforce certificate pinning and retries.
- Introduced `ALPHA_VANTAGE_FINGERPRINT` constant for explicit verification.
- Updated `_download_alpha_vantage_secure` to use the pinned session and handle `SecurityError`.
- Added `.flake8` configuration and new unit test `tests/test_ssl_pinning.py`.

### Testing Performed
- `black` formatting ran successfully.
- `flake8` and `mypy` executed but reported issues in existing files.
- `safety` failed due to blocked network access to `pyup.io`.
- Unit tests and security demo could not run because dependencies like pandas were unavailable.
- CLI performance test failed to run due to missing `keyring` dependency.

### Compliance Impact
Explicit SSL verification and certificate pinning enhance secure transmission requirements for PCI-DSS and SOX compliance.

### Breaking Changes
None.


------
https://chatgpt.com/codex/tasks/task_e_687bcca605dc83229b598f89cdeba085