### PR TITLE
[SECURITY] Fix SEC-2025-012: add rate limiting and circuit breaker

### DIFF
--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -1,0 +1,34 @@
+import asyncio
+import time
+import pytest
+from secure_ohlcv_downloader import RateLimiter, CircuitBreaker, SecurityError
+
+@pytest.mark.asyncio
+async def test_rate_limiter_waits():
+    rl = RateLimiter(1, 0.5)
+    start = time.monotonic()
+    await rl.acquire()
+    await rl.acquire()
+    elapsed = time.monotonic() - start
+    assert elapsed >= 0.5
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_opens():
+    cb = CircuitBreaker(2, 0.1)
+
+    async def fail():
+        raise ValueError()
+
+    with pytest.raises(ValueError):
+        await cb.call(fail)
+    with pytest.raises(ValueError):
+        await cb.call(fail)
+    with pytest.raises(SecurityError):
+        await cb.call(fail)
+    await asyncio.sleep(0.11)
+
+    async def succeed():
+        return True
+
+    result = await cb.call(succeed)
+    assert result is True


### PR DESCRIPTION
## Security Audit Remediation

**Finding ID**: SEC-2025-012
**Severity**: HIGH
**Category**: Security

### Problem Summary
Download methods performed unlimited API calls. This risked API quota exhaustion and service degradation.

### Solution Implemented
- Added `RateLimiter` implementing an async token bucket algorithm.
- Added `CircuitBreaker` to halt requests after repeated failures.
- Integrated these controls into Yahoo and Alpha Vantage downloads.
- Created async helper methods for HTTP requests with rate limiting and circuit breaker enforcement.
- Added unit tests for both components.

### Testing Performed
- ✅ `pytest` unit tests
- ❌ `security_test_demo.py` (blocked network access)

### Compliance Impact
Introduces availability protections aligning with operational resilience requirements.

### Breaking Changes
None.

------
https://chatgpt.com/codex/tasks/task_e_687bd463def083229f757d37e8653a41