### PR TITLE
Add config module for global limits

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+def _parse_oct(value: str, default: int) -> int:
+    try:
+        return int(value, 8)
+    except ValueError:
+        return default
+
+
+@dataclass
+class GlobalConfig:
+    max_api_response_size: int
+    max_date_range_days: int
+    request_timeout: int
+    dir_permissions: int
+    file_permissions: int
+
+
+def load_global_config(path: Optional[str] = None) -> GlobalConfig:
+    """Load configuration from JSON file and environment variables."""
+    data = {}
+    if path:
+        config_path = Path(path)
+        if config_path.is_file():
+            try:
+                data = json.loads(config_path.read_text())
+            except (OSError, json.JSONDecodeError):
+                data = {}
+    env = os.getenv
+    return GlobalConfig(
+        max_api_response_size=int(
+            data.get("max_api_response_size", env("MAX_API_RESPONSE_SIZE", "10485760"))
+        ),
+        max_date_range_days=int(
+            data.get("max_date_range_days", env("MAX_DATE_RANGE_DAYS", "3650"))
+        ),
+        request_timeout=int(
+            data.get("request_timeout", env("REQUEST_TIMEOUT", "30"))
+        ),
+        dir_permissions=_parse_oct(
+            str(data.get("dir_permissions", env("DIR_PERMISSIONS", "0o700"))),
+            0o700,
+        ),
+        file_permissions=_parse_oct(
+            str(data.get("file_permissions", env("FILE_PERMISSIONS", "0o600"))),
+            0o600,
+        ),
+    )
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,34 @@
+import json
+import os
+from datetime import date, timedelta
+import pytest
+
+from secure_ohlcv_downloader import SecureOHLCVDownloader, ValidationError
+from config import load_global_config
+
+
+def test_env_config_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("MAX_DATE_RANGE_DAYS", "1")
+    dl = SecureOHLCVDownloader(str(tmp_path))
+    start = date.today() - timedelta(days=2)
+    end = date.today()
+    with pytest.raises(ValidationError):
+        dl._validate_date_range(start, end)
+
+
+def test_file_config_loading(tmp_path, monkeypatch):
+    config_data = {
+        "max_api_response_size": 1,
+        "max_date_range_days": 2,
+        "request_timeout": 5,
+        "dir_permissions": "0700",
+        "file_permissions": "0600",
+    }
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config_data))
+    monkeypatch.setenv("OHLCV_CONFIG_FILE", str(config_path))
+    cfg = load_global_config(str(config_path))
+    assert cfg.max_date_range_days == 2
+    dl = SecureOHLCVDownloader(str(tmp_path))
+    assert dl.config.max_date_range_days == 2
+


### PR DESCRIPTION
## Summary
- centralize size/time/permission limits in new `config.py`
- inject configuration into CLI and downloader
- apply configurable limits for date range, request timeouts and file permissions
- test config loading from env vars and JSON files

## Testing
- `pip install -q pandas yfinance requests jsonschema cryptography keyring keyrings.alt regex pytest pytest-asyncio python-dotenv`
- `export PYTHONPATH=$PWD`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c67cbf14483229231449030b22f64