### PR TITLE
[SECURITY] Fix QUAL-2025-002: expand test coverage

### DIFF
--- a/security_test_demo.py
+++ b/security_test_demo.py
@@ -13,7 +13,13 @@ from pathlib import Path
 sys.path.insert(0, '/home/user/output')
 
 try:
-    from secure_ohlcv_downloader import SecureOHLCVDownloader, DownloadConfig, ValidationError, SecurityError
+    from secure_ohlcv_downloader import (
+        SecureOHLCVDownloader,
+        DownloadConfig,
+        ValidationError,
+        SecurityError,
+        CredentialError,
+    )
 except ImportError as e:
     print(f"❌ Import error: {e}")
     print("Make sure secure_ohlcv_downloader.py is in the current directory")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,39 @@
+import pytest
+from secure_ohlcv_downloader import SecureOHLCVDownloader, ValidationError, SecurityError
+
+
+def create_downloader(tmp_path):
+    return SecureOHLCVDownloader(str(tmp_path))
+
+
+def test_sanitize_error(tmp_path):
+    dl = create_downloader(tmp_path)
+    error = dl._sanitize_error("/tmp/secret.txt key=abcdef token=123")
+    assert "[PATH_REDACTED]" in error
+    assert "abcdef" not in error
+    assert "token=[REDACTED]" in error
+
+
+def test_validate_interval_invalid(tmp_path):
+    dl = create_downloader(tmp_path)
+    with pytest.raises(ValidationError):
+        dl._validate_interval("bad")
+
+
+def test_validate_source_invalid(tmp_path):
+    dl = create_downloader(tmp_path)
+    with pytest.raises(ValidationError):
+        dl._validate_source("badsource")
+
+
+def test_validate_date_key_length(tmp_path):
+    dl = create_downloader(tmp_path)
+    with pytest.raises(ValidationError):
+        dl._validate_date_key("2024-01-011")
+
+
+def test_validate_date_key_format(tmp_path):
+    dl = create_downloader(tmp_path)
+    with pytest.raises(ValidationError):
+        dl._validate_date_key("2024/01/01")
+


### PR DESCRIPTION
## Security Audit Remediation

**Finding ID**: QUAL-2025-002
**Severity**: MEDIUM
**Category**: Quality

### Problem Summary
Only a demonstration script existed for testing which left core
validation utilities untested.

### Solution Implemented
- Added `tests/test_validation.py` with unit tests for error
  sanitization and validation helpers.
- Updated `security_test_demo.py` to import `CredentialError`
  correctly so the demo script can execute without NameError.

### Testing Performed
- `PYTHONPATH=. pytest tests/ --cov=. --cov-report=term`
- `python security_test_demo.py` *(fails due to unrelated download issue)*

### Compliance Impact
Improves overall quality assurance by increasing automated test
coverage and validating security controls.

### Breaking Changes
None.

------
https://chatgpt.com/codex/tasks/task_e_687ca23a089c832285bd2416bcd20c4c