### PR TITLE
Optimize error sanitization logic

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -14,6 +14,13 @@ def test_sanitize_error(tmp_path):
     assert "token=[REDACTED]" in error
 
 
+def test_sanitize_error_password(tmp_path):
+    dl = create_downloader(tmp_path)
+    error = dl._sanitize_error("/tmp/secret.txt password=supersecret")
+    assert "password=[REDACTED]" in error
+    assert "supersecret" not in error
+
+
 def test_validate_interval_invalid(tmp_path):
     dl = create_downloader(tmp_path)
     with pytest.raises(ValidationError):


### PR DESCRIPTION
## Summary
- combine regexes for error sanitization into a single compiled pattern
- add sanitization timeout and group-based replacement
- extend tests for password sanitization

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce9608db083228d384f90d0eebb96