### PR TITLE
Implement streaming download with memory checks

### DIFF
--- a/config.py
+++ b/config.py
@@ -18,6 +18,8 @@ class GlobalConfig:
     max_api_response_size: int
     max_date_range_days: int
     request_timeout: int
+    chunk_size_days: int
+    max_memory_mb: int
     dir_permissions: int
     file_permissions: int
 
@@ -42,6 +44,12 @@ def load_global_config(path: Optional[str] = None) -> GlobalConfig:
         ),
         request_timeout=int(
             data.get("request_timeout", env("REQUEST_TIMEOUT", "30"))
+        ),
+        chunk_size_days=int(
+            data.get("chunk_size_days", env("CHUNK_SIZE_DAYS", "365"))
+        ),
+        max_memory_mb=int(
+            data.get("max_memory_mb", env("MAX_MEMORY_MB", "512"))
         ),
         dir_permissions=_parse_oct(
             str(data.get("dir_permissions", env("DIR_PERMISSIONS", "0o700"))),

--- a/tests/test_memory_management.py
+++ b/tests/test_memory_management.py
@@ -1,0 +1,37 @@
+import pandas as pd
+from datetime import date
+import types
+import psutil
+import pytest
+from secure_ohlcv_downloader import SecureOHLCVDownloader, SecurityError
+
+
+def test_download_yahoo_stream(monkeypatch, tmp_path):
+    dl = SecureOHLCVDownloader(str(tmp_path))
+    dl.config.chunk_size_days = 1
+    df1 = pd.DataFrame({"Open": [1], "High": [1], "Low": [1], "Close": [1], "Volume": [1]}, index=[pd.Timestamp("2024-01-01")])
+    df2 = pd.DataFrame({"Open": [2], "High": [2], "Low": [2], "Close": [2], "Volume": [2]}, index=[pd.Timestamp("2024-01-02")])
+    calls = [df1, df2]
+
+    async def fake_hist(*args, **kwargs):
+        return calls.pop(0)
+
+    monkeypatch.setattr(dl, "_yahoo_history", fake_hist)
+    file_path = tmp_path / "out.csv"
+    records = dl._download_yahoo_stream("AAPL", date(2024, 1, 1), date(2024, 1, 2), "1d", file_path)
+    assert records == 2
+    data = pd.read_csv(file_path, index_col=0)
+    assert len(data) == 2
+
+
+def test_check_memory(monkeypatch, tmp_path):
+    dl = SecureOHLCVDownloader(str(tmp_path))
+    dl.config.max_memory_mb = 1024
+
+    class FakeMem:
+        def __init__(self, available):
+            self.available = available
+
+    monkeypatch.setattr(psutil, "virtual_memory", lambda: FakeMem(100 * 1024 * 1024))
+    with pytest.raises(SecurityError):
+        dl._check_memory()


### PR DESCRIPTION
## Summary
- add chunk size and memory limit options to `GlobalConfig`
- stream large Yahoo Finance downloads to CSV
- encrypt existing CSV files when streaming
- add runtime memory checks
- test streaming download and memory protection

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ceb42e730832283385a8f8d355edf