### PR TITLE
Refactor error sanitization into shared utility

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -21,6 +21,17 @@ def test_sanitize_error_password(tmp_path):
     assert "supersecret" not in error
 
 
+def test_sanitize_error_function():
+    from utils import sanitize_error
+
+    msg = "/home/user/data key=mykey token=abc password=secret"
+    sanitized = sanitize_error(msg)
+    assert "[PATH_REDACTED]" in sanitized
+    assert "key=[REDACTED]" in sanitized
+    assert "token=[REDACTED]" in sanitized
+    assert "password=[REDACTED]" in sanitized
+
+
 def test_validate_interval_invalid(tmp_path):
     dl = create_downloader(tmp_path)
     with pytest.raises(ValidationError):

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,34 @@
+import regex
+from typing import Match
+
+try:
+    SANITIZE_PATTERN = regex.compile(
+        r"(?P<path>/\S+)|(?P<key>key[=:]\s*\S+)|(?P<token>token[=:]\s*\S+)|(?P<password>password[=:]\s*\S+)",
+        regex.IGNORECASE,
+        timeout=0.05,
+    )
+except Exception:
+    SANITIZE_PATTERN = regex.compile(
+        r"(?P<path>/\S+)|(?P<key>key[=:]\s*\S+)|(?P<token>token[=:]\s*\S+)|(?P<password>password[=:]\s*\S+)",
+        regex.IGNORECASE,
+    )
+
+
+def sanitize_error(error_message: str) -> str:
+    """Sanitize error messages to prevent information disclosure."""
+
+    def replacer(match: Match[str]) -> str:
+        if match.group("path"):
+            return "[PATH_REDACTED]"
+        if match.group("key"):
+            return "key=[REDACTED]"
+        if match.group("token"):
+            return "token=[REDACTED]"
+        if match.group("password"):
+            return "password=[REDACTED]"
+        return ""
+
+    try:
+        return SANITIZE_PATTERN.sub(replacer, error_message, timeout=0.05)
+    except regex.TimeoutError:
+        return "[SANITIZE_TIMEOUT]"


### PR DESCRIPTION
## Summary
- centralize error sanitization logic into new `utils.py`
- call new helper from `SecureOHLCVDownloader`
- add unit test for `sanitize_error`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf19ad7e483228cdf65e95ef691dc