### PR TITLE
[SECURITY] Fix QUAL-2025-004: Source-specific date validation

### DIFF
--- a/tests/test_cli_date_validation.py
+++ b/tests/test_cli_date_validation.py
@@ -1,0 +1,19 @@
+import pytest
+from secure_ohlcv_cli import SecureCLI
+
+def test_min_source_date(monkeypatch, tmp_path):
+    cli = SecureCLI()
+    parser = cli.create_parser()
+    args = parser.parse_args([
+        "AAPL",
+        "--source",
+        "alpha_vantage",
+        "--start-date",
+        "1998-12-31",
+        "--end-date",
+        "1999-01-02",
+        "--output-dir",
+        str(tmp_path),
+    ])
+    with pytest.raises(SystemExit):
+        cli._validate_arguments(args)


### PR DESCRIPTION
## Security Audit Remediation

**Finding ID**: QUAL-2025-004
**Severity**: LOW
**Category**: Quality

### Problem Summary
Date parsing allowed any value after 1900-01-01. This arbitrary lower bound did not match data availability and could waste API quota.

### Solution Implemented
- Added `MIN_SOURCE_DATES` mapping for Yahoo and Alpha Vantage.
- Removed the hardcoded historical limit from `_parse_date`.
- Extended `_validate_arguments` to check the earliest allowed date based on the selected source.
- Added unit test to ensure validation fails when requesting data prior to the supported range.

### Testing Performed
- [ ] Security tests pass
- [ ] Integration tests pass
- [ ] Manual verification completed
- [ ] Performance impact assessed

### Compliance Impact
Reduces unnecessary API traffic, supporting SOX controls on resource usage.

### Breaking Changes
None.


------
https://chatgpt.com/codex/tasks/task_e_687cf57f41608322a39914c3f655afb7