### PR TITLE
[SEC-2025-014] Enhance exception sanitization

### DIFF
--- a/tests/security/test_exception_sanitization.py
+++ b/tests/security/test_exception_sanitization.py
@@ -1,0 +1,25 @@
+import pytest
+from secure_ohlcv_downloader import SecurityExceptionHandler
+
+class TestExceptionSanitization:
+    """Security tests for exception context sanitization."""
+
+    def test_sensitive_data_removal(self):
+        handler = SecurityExceptionHandler()
+        sensitive_message = "API key abc123 failed at /home/user/secret/file.py"
+        exc = ValueError(sensitive_message)
+        sanitized = handler.sanitize_exception_context(exc)
+        assert 'abc123' not in sanitized['error_message']
+        assert '/home/user' not in sanitized['error_message']
+        assert '[REDACTED]' in sanitized['error_message']
+
+    def test_stack_trace_sanitization(self):
+        handler = SecurityExceptionHandler()
+        try:
+            raise ValueError("Test exception")
+        except Exception as e:
+            sanitized = handler.sanitize_exception_context(e, include_traceback=True)
+            for line in sanitized['traceback']:
+                assert '/home/' not in line
+                assert 'C:\\Users\\' not in line
+

--- a/tests/security/test_sec_2025_014_exception_sanitization.py
+++ b/tests/security/test_sec_2025_014_exception_sanitization.py
@@ -1,8 +1,0 @@
-import pytest
-
-class TestSecurityFinding:
-    """Placeholder tests for SEC-2025-014."""
-    
-    def test_placeholder(self):
-        """Placeholder test - will be implemented with actual security code."""
-        pytest.skip("Implementation pending")


### PR DESCRIPTION
## Summary
- add `SecurityExceptionHandler` for structured exception logging
- sanitize stack traces and local variables
- integrate handler with downloader and update `_sanitize_error`
- log security events via `_handle_security_exception`
- add tests for exception sanitization

## Testing
- `python -m pytest tests/security/ -v --tb=short`
- `python -m bandit -r . -f json -o security_scan.json`
- `python -m safety check --json > safety_report.json`
- `flake8 --select=E9,F63,F7,F82 . --output-file=flake8_report.txt`
- `mypy . > mypy_report.txt`
- `python -m pytest tests/integration/ -k security -v --tb=short`
- `python scripts/performance_baseline.py --output=perf_report.json`


------
https://chatgpt.com/codex/tasks/task_e_687d1c8643c483229feb7518f7d2ac3f