### PR TITLE
Fix PERF-2025-001 async file writes

### DIFF
--- a/secure_ohlcv_downloader.py
+++ b/secure_ohlcv_downloader.py
@@ -13,6 +13,15 @@ from src.secure_ohlcv_downloader import (
     SecurityError,
     CredentialError,
     ValidationError,
+    CertificateManager,
+    SecurePatternValidator,
+    SecureJSONValidator,
+    DataValidator,
+    APIClient,
+    EncryptionManager,
+    FileManager,
+    ConfigurationManager,
+    SecurityValidationError,
 )
 
 from dataclasses import dataclass
@@ -78,6 +87,15 @@ __all__ = [
     "ValidationError",
     "SecurityExceptionHandler",
     "DownloadConfig",
+    "CertificateManager",
+    "SecurePatternValidator",
+    "SecureJSONValidator",
+    "DataValidator",
+    "APIClient",
+    "EncryptionManager",
+    "FileManager",
+    "ConfigurationManager",
+    "SecurityValidationError",
 ]
 
 


### PR DESCRIPTION
## Summary
- convert file operations in `FileManager` to use `aiofiles`
- export full API surface in wrapper `secure_ohlcv_downloader.py`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'RateLimiter')*

------
https://chatgpt.com/codex/tasks/task_e_687d429d98508322a2f952b4d5f2fccb