### PR TITLE
Improve security docstrings

### DIFF
--- a/secure_ohlcv_downloader.py
+++ b/secure_ohlcv_downloader.py
@@ -48,6 +48,13 @@ class SecurityExceptionHandler:
         self.security_logger = logging.getLogger("security")
 
     def sanitize_exception_context(self, exc: Exception, include_traceback: bool = False) -> Dict[str, Any]:
+        """Return a sanitized dictionary describing *exc*.
+
+        Edge cases: unexpected exception types may include sensitive user input
+        or file paths. This helper removes known secrets and optionally the
+        traceback to avoid information disclosure while still providing
+        actionable diagnostics.
+        """
         context = {
             "error_type": type(exc).__name__,
             "error_message": self._sanitize_message(str(exc)),

--- a/src/secure_ohlcv_downloader/configuration.py
+++ b/src/secure_ohlcv_downloader/configuration.py
@@ -17,6 +17,12 @@ class ConfigurationManager:
         self.config = load_global_config(config_path)
 
     def get_api_key(self, service: str) -> Optional[str]:
+        """Retrieve an API key from environment or system keyring.
+
+        Security requirement: keys must never be hardcoded. Environment
+        variables are checked first to support containerized deployments,
+        falling back to the OS keyring for local usage.
+        """
         key_name = f"{service.upper()}_API_KEY"
         api_key = os.getenv(key_name)
         if not api_key:

--- a/src/secure_ohlcv_downloader/encryption.py
+++ b/src/secure_ohlcv_downloader/encryption.py
@@ -10,18 +10,36 @@ class EncryptionManager:
     """Encrypt and decrypt byte strings securely."""
 
     def __init__(self) -> None:
+        """Initialize the encryption context.
+
+        Security assumption: the symmetric key is provided via the
+        ``OHLCV_ENCRYPTION_KEY`` environment variable. If absent, a new key
+        is generated at runtime which limits decryption to the current
+        session only.
+        """
         key = os.getenv("OHLCV_ENCRYPTION_KEY")
         if not key:
             key = Fernet.generate_key().decode()
         self.cipher = Fernet(key.encode())
 
     def encrypt(self, data: bytes) -> bytes:
+        """Encrypt *data* using Fernet.
+
+        Attack scenario: encryption failures may leak plaintext if not
+        handled. Exceptions are trapped and re-raised as
+        :class:`SecurityError` to avoid exposing implementation details.
+        """
         try:
             return self.cipher.encrypt(data)
         except Exception as exc:  # pragma: no cover - library errors
             raise SecurityError(str(exc))
 
     def decrypt(self, data: bytes) -> bytes:
+        """Decrypt *data* using Fernet.
+
+        Invalid or tampered ciphertext raises :class:`SecurityError` to
+        prevent attackers from gleaning information through error messages.
+        """
         try:
             return self.cipher.decrypt(data)
         except InvalidToken as exc:


### PR DESCRIPTION
## Summary
- add security-focused docstrings to validator methods
- enhance encryption, API client, file manager, and file lock documentation
- clarify credential retrieval and exception sanitization docs

## Testing
- `python scripts/run_validation.py` *(fails: bandit, safety, mypy)*

------
https://chatgpt.com/codex/tasks/task_e_687d7877bac08322b54d864bb56c7ffa