### PR TITLE
Implement cleanup expired data routine

### DIFF
--- a/tests/security/test_cleanup_expired_files.py
+++ b/tests/security/test_cleanup_expired_files.py
@@ -1,0 +1,26 @@
+import os
+import asyncio
+from datetime import datetime, timedelta
+from pathlib import Path
+from secure_ohlcv_downloader import SecureOHLCVDownloader
+
+
+def test_cleanup_expired_files(tmp_path: Path) -> None:
+    dl = SecureOHLCVDownloader(str(tmp_path))
+    old_dir = tmp_path / "data" / "AAPL" / "old"
+    old_dir.mkdir(parents=True)
+    old_file = old_dir / "old.csv"
+    old_file.write_text("x")
+    old_time = datetime.now() - timedelta(days=10)
+    os.utime(old_file, (old_time.timestamp(), old_time.timestamp()))
+
+    new_dir = tmp_path / "data" / "AAPL" / "new"
+    new_dir.mkdir(parents=True)
+    new_file = new_dir / "new.csv"
+    new_file.write_text("y")
+
+    asyncio.run(dl.cleanup_expired_data(7))
+
+    assert not old_file.exists()
+    assert not old_dir.exists()
+    assert new_file.exists()


### PR DESCRIPTION
## Summary
- implement async cleanup to remove old data files
- add tests verifying expired file cleanup

## Testing
- `python -m pytest tests/security/ -v --tb=short`
- `python -m bandit -r . -f json -o security_scan.json`
- `python -m safety check --json > safety_report.json`
- `flake8 --select=E9,F63,F7,F82 . --output-file=flake8_report.txt`
- `mypy . --pretty`
- `python -m pytest tests/integration/ -k security -v --tb=short`
- `python scripts/performance_baseline.py --output=perf_report.json`


------
https://chatgpt.com/codex/tasks/task_e_687d878ea0e48322be16710b0c772641