### PR TITLE
Refactor CLI run method

### DIFF
--- a/secure_ohlcv_cli.py
+++ b/secure_ohlcv_cli.py
@@ -452,53 +452,53 @@ Examples:
             print(f"❌ Validation Error: {e}")
             sys.exit(1)
 
+    def _handle_special_commands(self, args: argparse.Namespace) -> bool:
+        """Handle CLI options that exit early."""
+        if args.check_env:
+            self._check_environment()
+            return True
+        return False
+
+    def _execute_download(self, args: argparse.Namespace) -> None:
+        """Validate inputs, setup environment, and run download."""
+        self._validate_arguments(args)
+        self._setup_secure_environment(args)
+
+        config = DownloadConfig(
+            ticker=args.ticker,
+            start_date=args.start_date,
+            end_date=args.end_date,
+            interval=args.interval,
+            source=args.source,
+            encrypt_data=args.encrypt,
+        )
+
+        print("🚀 Starting secure download...")
+        print(f"   Ticker: {config.ticker}")
+        print(f"   Source: {config.source}")
+        print(f"   Date Range: {config.start_date} to {config.end_date}")
+        print(f"   Interval: {config.interval}")
+        print(f"   Encryption: {'Enabled' if config.encrypt_data else 'Disabled'}")
+
+        file_path = self.downloader.download_data(config)
+
+        print("✅ Download completed successfully!")
+        print(f"   File saved: {file_path}")
+        print(f"   Check logs: {args.output_dir}/secure_downloader.log")
+
     def run(self) -> None:
-        """
-        Main CLI execution with comprehensive error handling
-        """
+        """Main CLI execution with comprehensive error handling."""
         parser = self.create_parser()
         args = parser.parse_args()
 
-        # Handle special commands
-        if args.check_env:
-            self._check_environment()
+        if self._handle_special_commands(args):
             return
 
         try:
-            # Validate arguments
-            self._validate_arguments(args)
-
-            # Setup secure environment
-            self._setup_secure_environment(args)
-
-            # Create download configuration
-            config = DownloadConfig(
-                ticker=args.ticker,
-                start_date=args.start_date,
-                end_date=args.end_date,
-                interval=args.interval,
-                source=args.source,
-                encrypt_data=args.encrypt,
-            )
-
-            # Execute download
-            print(f"🚀 Starting secure download...")
-            print(f"   Ticker: {config.ticker}")
-            print(f"   Source: {config.source}")
-            print(f"   Date Range: {config.start_date} to {config.end_date}")
-            print(f"   Interval: {config.interval}")
-            print(f"   Encryption: {'Enabled' if config.encrypt_data else 'Disabled'}")
-
-            file_path = self.downloader.download_data(config)
-
-            print(f"✅ Download completed successfully!")
-            print(f"   File saved: {file_path}")
-            print(f"   Check logs: {args.output_dir}/secure_downloader.log")
-
+            self._execute_download(args)
         except KeyboardInterrupt:
             print("\n⚠️  Download interrupted by user")
             sys.exit(1)
-
         except (ValidationError, SecurityError, CredentialError, OSError, requests.RequestException) as e:
             print(f"❌ Security/Validation Error: {e}")
             sys.exit(1)

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+from secure_ohlcv_cli import SecureCLI
+
+
+def test_cli_run_invokes_download(monkeypatch, tmp_path):
+    cli = SecureCLI()
+    called = {}
+
+    def dummy_setup(args):
+        class Dummy:
+            def download_data(self, config):
+                called["cfg"] = config
+                return Path(tmp_path) / "data.csv"
+        cli.downloader = Dummy()
+
+    monkeypatch.setattr(cli, "_setup_secure_environment", dummy_setup)
+    monkeypatch.setattr(sys, "argv", ["prog", "AAPL", "--start-date", "2024-01-01", "--end-date", "2024-01-02", "--output-dir", str(tmp_path)])
+    cli.run()
+    assert called["cfg"].ticker == "AAPL"
+
+
+def test_cli_check_env(monkeypatch):
+    cli = SecureCLI()
+    called = {"env": False}
+    monkeypatch.setattr(cli, "_check_environment", lambda: called.__setitem__("env", True))
+    monkeypatch.setattr(sys, "argv", ["prog", "AAPL", "--check-env"])
+    cli.run()
+    assert called["env"] is True


### PR DESCRIPTION
## Summary
- split `run` into `_handle_special_commands` and `_execute_download`
- add tests covering CLI invocation

## Testing
- `python -m pytest tests/test_cli_run.py -v --tb=short`
- `python -m pytest tests/security/ -v --tb=short`
- `python -m bandit -r . -f json -o security_scan.json` *(fails: No module named bandit)*
- `python -m safety check --json --output safety_report.json` *(fails: No module named safety)*
- `flake8 --select=E9,F63,F7,F82 . --output-file=flake8_report.txt` *(fails: command not found)*
- `mypy . --output=mypy_report.txt` *(fails: invalid choice)*
- `python -m pytest tests/integration/ -k security -v --tb=short` *(fails: async plugin missing)*
- `python scripts/performance_baseline.py --output=perf_report.json`

------
https://chatgpt.com/codex/tasks/task_e_687ed6370b708322b56b0e31a81b038e